### PR TITLE
Fix: push_settigsテーブルからpush_timeカラムを消去

### DIFF
--- a/db/migrate/20210723064127_remove_push_day_from_push_settings.rb
+++ b/db/migrate/20210723064127_remove_push_day_from_push_settings.rb
@@ -1,0 +1,5 @@
+class RemovePushDayFromPushSettings < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :push_settings, :push_day, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_10_022326) do
+ActiveRecord::Schema.define(version: 2021_07_23_064127) do
 
   create_table "push_settings", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.integer "push_day", null: false
     t.string "push_time", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false


### PR DESCRIPTION
## 概要
push_settigsテーブルからpush_timeカラムを消去
曜日設定はやらない方向で修正
